### PR TITLE
Make environment specification more flexible

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,101 +1,15 @@
-# This environment works on Mac
-name: magnolia
+name: magnolia3
 channels: !!python/tuple
 - defaults
 dependencies:
-- _nb_ext_conf=0.3.0=py27_0
-- anaconda-client=1.6.0=py27_0
-- appnope=0.1.0=py27_0
-- backports=1.0=py27_0
-- backports_abc=0.5=py27_0
-- clyent=1.2.2=py27_0
-- conda-forge::altair=1.2.0=py27_0
-- conda-forge::vega=0.4.4=py27_0
-- configparser=3.5.0=py27_0
-- cycler=0.10.0=py27_0
-- decorator=4.0.10=py27_1
-- entrypoints=0.2.2=py27_0
-- enum34=1.1.6=py27_0
-- freetype=2.5.5=1
-- functools32=3.2.3.2=py27_0
-- get_terminal_size=1.0.0=py27_0
-- icu=54.1=0
-- ipykernel=4.5.2=py27_0
-- ipython=5.1.0=py27_1
-- ipython_genutils=0.1.0=py27_0
-- ipywidgets=5.2.2=py27_0
-- jinja2=2.8=py27_1
-- jsonschema=2.5.1=py27_0
-- jupyter=1.0.0=py27_3
-- jupyter_client=4.4.0=py27_0
-- jupyter_console=5.0.0=py27_0
-- jupyter_core=4.2.1=py27_0
-- libpng=1.6.22=0
-- markupsafe=0.23=py27_2
-- matplotlib=1.5.3=np111py27_1
-- mistune=0.7.3=py27_1
-- mkl=11.3.3=0
-- nb_anacondacloud=1.2.0=py27_0
-- nb_conda=2.0.0=py27_0
-- nb_conda_kernels=2.0.0=py27_0
-- nbconvert=4.2.0=py27_0
-- nbformat=4.2.0=py27_0
-- nbpresent=3.0.2=py27_0
-- notebook=4.3.0=py27_0
-- numpy=1.11.2=py27_0
-- openssl=1.0.2j=0
-- pandas=0.19.2=np111py27_0
-- path.py=9.0.1=py27_0
-- pathlib2=2.1.0=py27_0
-- pexpect=4.0.1=py27_0
-- pickleshare=0.7.4=py27_0
-- pip=9.0.1=py27_1
-- prompt_toolkit=1.0.9=py27_0
-- ptyprocess=0.5.1=py27_0
-- pygments=2.1.3=py27_0
-- pyparsing=2.1.4=py27_0
-- pyqt=5.6.0=py27_1
-- python=2.7.13=0
-- python-dateutil=2.6.0=py27_0
-- pytz=2016.10=py27_0
-- pyyaml=3.12=py27_0
-- pyzmq=16.0.2=py27_0
-- qt=5.6.2=0
-- qtconsole=4.2.1=py27_1
-- readline=6.2=2
-- requests=2.12.4=py27_0
-- scikit-learn=0.18.1=np111py27_0
-- scipy=0.18.1=np111py27_0
-- setuptools=27.2.0=py27_0
-- simplegeneric=0.8.1=py27_1
-- singledispatch=3.4.0.3=py27_0
-- sip=4.18=py27_0
-- six=1.10.0=py27_0
-- sqlite=3.13.0=0
-- ssl_match_hostname=3.4.0.2=py27_1
-- terminado=0.6=py27_0
-- tk=8.5.18=0
-- tornado=4.4.2=py27_0
-- traitlets=4.3.1=py27_0
-- wcwidth=0.1.7=py27_0
-- wheel=0.29.0=py27_0
-- widgetsnbextension=1.2.6=py27_0
-- yaml=0.1.6=0
-- zlib=1.2.8=3
+- conda-forge::altair
+- conda-forge::pandas
+- conda-forge::matplotlib
+- python=3
+- numpy
+- scipy
+- scikit-learn
 - pip:
-  - backports-abc==0.5
-  - backports.shutil-get-terminal-size==1.0.0
-  - backports.ssl-match-hostname==3.4.0.2
-  - certifi==2016.9.26
-  - ipython-genutils==0.1.0
-  - jupyter-client==4.4.0
-  - jupyter-console==5.0.0
-  - jupyter-core==4.2.1
-  - nb-anacondacloud==1.2.0
-  - nb-conda==2.0.0
-  - nb-conda-kernels==2.0.0
-  - prompt-toolkit==1.0.9
-  - scikits.audiolab==0.11.0
-  - theano==0.8.2
-prefix: /Users/patrickc/anaconda3/envs/magnolia
-
+  - tensorflow
+  - python_speech_features
+  - theano


### PR DESCRIPTION
Removing some packages allows conda to resolve dependencies in a more platform-independent way. Was not able to get scikits.audiolab to install on our remote environment, so I removed it, though nothing would stop users from installing it if they needed it. Also removed an unnecessary user-specific prefix from the previous version.