### PR TITLE
Allow Hdf5Iterator to handle dimension mismatch in shape

### DIFF
--- a/src/features/data_preprocessing.py
+++ b/src/features/data_preprocessing.py
@@ -7,7 +7,7 @@ import h5py
 import numpy as np
 import soundfile as sf
 from scipy.signal import resample_poly
-from spectral_features import stft, istft
+from features.spectral_features import stft, istft
 from python_speech_features.sigproc import preemphasis
 
 def make_stft_features(signal, sample_rate,

--- a/src/features/hdf5_iterator.py
+++ b/src/features/hdf5_iterator.py
@@ -77,9 +77,10 @@ class Hdf5Iterator:
 
             # Replace nones in shape with dims from next_item
             for j, dim in enumerate(next_item.shape):
-                if shape[j] is None:
+                logger.debug("dim {}: {}".format(j , dim))
+                if j < len(shape) and shape[j] is None:
                     shape[j] = dim
-                    logger.debug("dim {}: {}".format(j , dim))
+                   
             logger.debug("shape: {}".format(shape))
 
             # fail if this slice is out of bounds
@@ -99,7 +100,7 @@ class Hdf5Iterator:
                 slices.append(slice(slice_start, slice_end))
             output_slice = next_item[tuple(slices)]
             logger.debug("slices: {}".format(slices))
-            assert output_slice.shape == tuple(shape), "Result shape {} does not match " \
+            assert output_slice.shape[:len(shape)] == tuple(shape), "Result shape {} does not match " \
                     "target shape {}".format(output_slice.shape, shape)
             logger.debug("Returning.")
             return output_slice


### PR DESCRIPTION
Hdf5Iterator currently barfs if the `shape` parameter is lower dimension than the resulting slices from the data; now it handles this case gracefully as long as the first dimensions of shape match what is coming out of the data