### PR TITLE
There was a bug in the splits_iterator

### DIFF
--- a/src/features/hdf5_iterator.py
+++ b/src/features/hdf5_iterator.py
@@ -224,6 +224,8 @@ class SplitsIterator(Hdf5Iterator):
         Args:
             index: which split are you going to use?
         '''
+        
+        self.speaker_subset( self.h5_groups )
         self.split_index = index
         self.h5_items = self.split_list[index]
             


### PR DESCRIPTION
Fixed it so that subsets are maintained even if speaker keys are involved.