### PR TITLE
Install conda env, TF and magnolia in one go

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -1,18 +1,16 @@
-name: magnolia3
+name: magnolia3-cpu
 channels: !!python/tuple
 - defaults
 dependencies:
 - conda-forge::altair
 - conda-forge::pandas
 - conda-forge::matplotlib
-- python=3
+- python=3.5
 - numpy
 - scipy
 - scikit-learn
 - seaborn
 - pip:
-  - tensorflow
   - python_speech_features
   - theano
   - soundfile
-

--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -5,6 +5,8 @@ dependencies:
 - conda-forge::altair
 - conda-forge::pandas
 - conda-forge::matplotlib
+- flask
+- h5py
 - python=3.5
 - numpy
 - scipy
@@ -14,3 +16,4 @@ dependencies:
   - python_speech_features
   - theano
   - soundfile
+  - keras

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -1,0 +1,16 @@
+name: magnolia3-gpu
+channels: !!python/tuple
+- defaults
+dependencies:
+- conda-forge::altair
+- conda-forge::pandas
+- conda-forge::matplotlib
+- python=3.5
+- numpy
+- scipy
+- scikit-learn
+- seaborn
+- pip:
+  - python_speech_features
+  - theano
+  - soundfile

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -5,6 +5,8 @@ dependencies:
 - conda-forge::altair
 - conda-forge::pandas
 - conda-forge::matplotlib
+- flask
+- h5py
 - python=3.5
 - numpy
 - scipy
@@ -14,3 +16,4 @@ dependencies:
   - python_speech_features
   - theano
   - soundfile
+  - keras

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Set up dependencies and install one version of the magnolia environment
+
+set -e
+
+if [[ $OSTYPE == darwin* ]]; then
+    TF_URL_GPU="https://storage.googleapis.com/tensorflow/mac/gpu/tensorflow_gpu-1.1.0-py3-none-any.whl"
+    TF_URL_CPU="https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.1.0-py3-none-any.whl"
+else
+    TF_URL_GPU="https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.1.0-cp35-cp35m-linux_x86_64.whl"
+    TF_URL_CPU="https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.1.0-cp35-cp35m-linux_x86_64.whl"
+fi
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+while [[ $# -ge 1 ]]
+do
+key="$1"
+
+case $key in
+    --gpu|-g)
+    GPU="true"
+    if [[ "$TF_URL" == "" ]]; then
+        TF_URL="$TF_URL_GPU"
+    fi
+    ;;
+    --tf-url|-t)
+    TF_URL="$2"
+    shift
+    ;;
+    *)
+    echo "install.sh -- Install dependencies, conda environment and package for "
+    echo " Magnolia project."
+    echo
+    echo "Options:"
+    printf " --gpu|-g\t\tInstall GPU version of tensorflow\n"
+    printf " --tf-url|-t URL\t\tInstall from this Tensorflow URL (1.1 by default)\n\n"
+    exit
+            # unknown option
+    ;;
+esac
+shift # past argument or value
+done
+
+# Fall back to CPU tensorflow
+if [[ "$TF_URL" == "" ]]; then
+    TF_URL="$TF_URL_CPU"
+fi
+
+if [[ "$GPU" == "true" ]]; then
+    conda create -f "$DIR"/environment-gpu.yml
+    # ungodly hack here (get path prefix for new environment)
+    ENV_PREFIX=$(conda info --envs --json | python -c 'import json; import sys; print("\n".join([env for env in json.loads(sys.stdin.read())["envs"] if "magnolia3-gpu" in env]))')
+    echo "New environment: $ENV_PREFIX"
+else
+    conda env create --force -f "$DIR"/environment-cpu.yml
+
+    # ungodly hack here (get path prefix for new environment)
+    ENV_PREFIX=$(conda info --envs --json | python -c 'import json; import sys; print("\n".join([env for env in json.loads(sys.stdin.read())["envs"] if "magnolia3-cpu" in env]))')
+    echo "New environment: $ENV_PREFIX"
+fi
+
+# Install tensorflow
+"$ENV_PREFIX"/bin/pip install --upgrade "$TF_URL"
+
+# Install Magnolia
+"$ENV_PREFIX"/bin/pip install --upgrade --no-deps "$DIR"

--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,7 @@ if [[ "$TF_URL" == "" ]]; then
 fi
 
 if [[ "$GPU" == "true" ]]; then
-    conda create -f "$DIR"/environment-gpu.yml
+    conda env create -f "$DIR"/environment-gpu.yml
     # ungodly hack here (get path prefix for new environment)
     ENV_PREFIX=$(conda info --envs --json | python -c 'import json; import sys; print("\n".join([env for env in json.loads(sys.stdin.read())["envs"] if "magnolia3-gpu" in env]))')
     echo "New environment: $ENV_PREFIX"


### PR DESCRIPTION
Creates a conda env `magnolia3-cpu` (by default) or `magnolia3-gpu` (if selected) from environment-*.yml files in the repo root. Installs the appropriate tensorflow 1.1 by URL into the new environment. Installs magnolia into the environment. Option to provide an alternative tensorflow wheel URL.

Need to test that install works in our Jupyter servers.